### PR TITLE
Fix: Add @unknown default to WebSocketEvent switch to ensure exhaustive handling

### DIFF
--- a/Sources/Channel.swift
+++ b/Sources/Channel.swift
@@ -89,6 +89,8 @@ public class Channel{
                     case .ping(_): break
                     case .viabilityChanged(_): break
                     case .reconnectSuggested(_): break
+                    @unknown default:
+                        break
                 }
             }
         }catch PieSocketException.PausedForFetchingJwt{


### PR DESCRIPTION
### Summary
This patch fixes a compiler error related to non-exhaustive switch statements in the WebSocket event handler (likely from Starscream used by PieSocket). It adds an `@unknown default` case to future-proof the switch and ensure stability with SDK updates.

### Changes
- Added `@unknown default` to WebSocketEvent switch block
- Prevents build failures when the SDK introduces new enum cases
- Keeps event handling logic safe and extensible